### PR TITLE
PyPI Packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,21 @@
+import pathlib
+from setuptools import setup
+
+# The directory containing this file
+HERE = pathlib.Path(__file__).parent
+# The text of the README file
+README = (HERE / "README.md").read_text()
+
+setup(
+    name='mimic',
+    version='0.0.1',
+    packages=['mimic', 'mimic.model', 'mimic.tests'],
+    url='https://github.com/ubclaunchpad/mimic',
+    license='MIT',
+    author='ubclaunchpad',
+    author_email='',
+    description='ML-powered Text Generation Library',
+    long_description=README,
+    long_description_content_type="text/markdown",
+    include_package_data=True
+)

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+"""Setup file for to configure distribution upload to PyPI."""
+
 import pathlib
 from setuptools import setup
 
@@ -7,7 +9,7 @@ HERE = pathlib.Path(__file__).parent
 README = (HERE / "README.md").read_text()
 
 setup(
-    name='mimic',
+    name='mimic-text',
     version='0.0.1',
     packages=['mimic', 'mimic.model', 'mimic.tests'],
     url='https://github.com/ubclaunchpad/mimic',
@@ -19,3 +21,10 @@ setup(
     long_description_content_type="text/markdown",
     include_package_data=True
 )
+
+# How to upload to pypi (Remember to change version number):
+# Run these commands in terminal:
+#   python setup.py sdist bdist_wheel
+#   tar tzf dist/mimic-text-0.0.1.tar.gz    # Checks to see if dist file made
+#   twine check dist/*                      # Check if dist can be uploaded
+#   twine upload dist/*                     # Uploads to PyPI


### PR DESCRIPTION
# Pull Request

## Description

Added setup.py and MANIFEST.in (currently empty) files.
- setup.py configures the package distribution to be upload
- MANIFEST.in specifies any non python/source code files to be included

The first version is already up on PyPI
- Search for mimic-text on pypi.org to see our library (mimic was taken already)
- Future versions can be uploaded later 
- Includes mimic, mimic.model, and mimic.tests
- run pip install mimic-text to download packages

## Testing

If testing this change requires extra setup, please document it here:

## Ticket(s)

Closes #21 
